### PR TITLE
Fix PyCharm warnings: "Cannot find reference `request` in `PhantomJS | WebDriver`"

### DIFF
--- a/seleniumrequests/__init__.py
+++ b/seleniumrequests/__init__.py
@@ -1,43 +1,44 @@
-from selenium.webdriver import Firefox, Chrome, Ie, Edge, Opera, Safari, BlackBerry, PhantomJS, Android, Remote
+from selenium.webdriver import _Firefox, _Chrome, _Ie, _Edge, _Opera, _Safari, _BlackBerry, _PhantomJS, _Android, \
+    _Remote
 
 from seleniumrequests.request import RequestsSessionMixin
 
 
-class Firefox(RequestsSessionMixin, Firefox):
+class Firefox(RequestsSessionMixin, _Firefox):
     pass
 
 
-class Chrome(RequestsSessionMixin, Chrome):
+class Chrome(RequestsSessionMixin, _Chrome):
     pass
 
 
-class Ie(RequestsSessionMixin, Ie):
+class Ie(RequestsSessionMixin, _Ie):
     pass
 
 
-class Edge(RequestsSessionMixin, Edge):
+class Edge(RequestsSessionMixin, _Edge):
     pass
 
 
-class Opera(RequestsSessionMixin, Opera):
+class Opera(RequestsSessionMixin, _Opera):
     pass
 
 
-class Safari(RequestsSessionMixin, Safari):
+class Safari(RequestsSessionMixin, _Safari):
     pass
 
 
-class BlackBerry(RequestsSessionMixin, BlackBerry):
+class BlackBerry(RequestsSessionMixin, _BlackBerry):
     pass
 
 
-class PhantomJS(RequestsSessionMixin, PhantomJS):
+class PhantomJS(RequestsSessionMixin, _PhantomJS):
     pass
 
 
-class Android(RequestsSessionMixin, Android):
+class Android(RequestsSessionMixin, _Android):
     pass
 
 
-class Remote(RequestsSessionMixin, Remote):
+class Remote(RequestsSessionMixin, _Remote):
     pass


### PR DESCRIPTION
Fix PyCharm warnings like this: "Cannot find reference `request` in `PhantomJS | WebDriver`"