### PR TITLE
fix: 🐛 Hotfix for request headers window handling the wrong request

### DIFF
--- a/seleniumrequests/request.py
+++ b/seleniumrequests/request.py
@@ -61,11 +61,12 @@ def get_webdriver_request_headers(webdriver):
         except socket.error:
             pass
 
-    threading.Thread(target=server.handle_request).start()
+    threading.Thread(target=server.serve_forever).start()
     original_window_handle = webdriver.current_window_handle
     webdriver.execute_script("window.open('http://127.0.0.1:%d/', '_blank');" % port)
 
     UPDATER_HEADERS_MUTEX.acquire()
+    server.shutdown()
 
     # Not optional: Make sure that the webdriver didn't switch the window handle to the newly opened window. Behaviors
     # of different webdrivers seem to differ here. Workaround for Firefox: If a new window is opened via JavaScript as a


### PR DESCRIPTION
In some situations, the headers window server would receive a request
that was not the request to get the headers.
This would shutdown the server and hang the window.