### PR TITLE
add option to specify address of the proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,16 @@ print(response)
 Installation
 ------------
 ```pip install selenium-requests```
+
+Remote WebDriver
+----------------
+When using `webdriver.Remote` it is very likely that the HTTP Proxy Server spawned by `selenium-requests` does not run on the same machine. By default the webdriver tries to access the Proxy Server under `127.0.0.1`. This can be changed by passing the `proxy_host=` argument with the correct IP or hostname to the webdriver.
+
+```python
+driver = seleniumrequests.Remote(
+    'http://192.168.101.1:4444/wd/hub',
+    options=chrome_options,
+    proxy_host='192.168.101.2'
+    )
+
+```


### PR DESCRIPTION
Hello,

this adds an option to set the host of the request to the proxy server to something different than `127.0.0.1`. I think this is particularly useful if working with `webdriver.Remote`, where the webdriver may run on a completely different machine/host than the selenium script providing the HTTP proxy.

In my case I use the standalone docker images of selenium (browser and webdriver) and control these from a different docker container running my selenium scripts.

The changes should be backward compatible since omitting the argument defaults to the previous value.

I'm happy for any feedback. If the suggested changes are out of scope of this repo, I will keep them in my own fork only.